### PR TITLE
Ignores expected changes to VMs

### DIFF
--- a/src/terraform/main.tf
+++ b/src/terraform/main.tf
@@ -54,6 +54,13 @@ resource "vsphere_virtual_machine" "control_plane" {
   name     = "${local.vm_prefix}-control-plane-${random_id.control_plane.hex}"
   count    = var.controllers
 
+  lifecycle { 
+    ignore_changes = [
+      host_system_id,
+      ept_rvi_mode,
+      hv_mode
+    ]
+  }
   datacenter_id    = data.vsphere_datacenter.datacenter.id
   datastore_id     = data.vsphere_datastore.datastore.id
   resource_pool_id = data.vsphere_resource_pool.resource_pool.id
@@ -125,6 +132,15 @@ resource "random_id" "worker" {
 resource "vsphere_virtual_machine" "worker" {
   name     = "${local.vm_prefix}-worker-${random_id.worker[count.index].hex}"
   count    = var.workers
+
+  lifecycle { 
+    ignore_changes = [
+      host_system_id,
+      disk,
+      ept_rvi_mode,
+      hv_mode
+    ]
+  }
 
   datacenter_id    = data.vsphere_datacenter.datacenter.id
   datastore_id     = data.vsphere_datastore.datastore.id


### PR DESCRIPTION
TL;DR
-----

Avoids updating VMs for changes vSphere and Kubernetes make

Details
-------

Sets a lifecycle argument on the cluster VMs to avoid spurious and
potentially distruptive changes.

* Doesn't worry about which host the VM is on or fields that vSphere
  changes regularly from the defaults
* Ignores mounted disks on workers, since they are likely Kubernetes
  volumes and should stay attached.
