### PR TITLE
Adds Wireguard

### DIFF
--- a/src/terraform/templates/k0sctl.tftpl
+++ b/src/terraform/templates/k0sctl.tftpl
@@ -92,6 +92,7 @@ spec:
             mode: iptables
           calico:
             overlay: CrossSubnet
+            wireguard: true
           podCIDR: 10.244.0.0/16
           provider: calico
           serviceCIDR: 10.96.0.0/12

--- a/src/terraform/templates/user-data.tftpl
+++ b/src/terraform/templates/user-data.tftpl
@@ -21,6 +21,7 @@ chpasswd:
 packages:
 - open-vm-tools
 - ca-certificates
+- wireguard
 - curl
 - zsh
 - neovim


### PR DESCRIPTION
TL;DR
-----

Enables Wireguard for Calico

Details
-------

Confiures the clutser to use Calico's built in support for
Wireguard for increased security.
