### PR TITLE
Assures that vSAN is the default storage class

### DIFF
--- a/manifests/vsphere-csi/03-vsan-storageclass.yaml
+++ b/manifests/vsphere-csi/03-vsan-storageclass.yaml
@@ -1,0 +1,9 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: vsan
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: csi.vsphere.vmware.com
+parameters:
+  storagepolicyname: vsan


### PR DESCRIPTION
TL;DR
-----

Provides a storage class using vSAN as default to the cluster

Details
-------

Creates a manifest defining a storage class `vsan` that uses the
vSphere storage provider and is default for the cluster. The
manifest is synced to the controller and deploying using the manifest
deployer.
