### PR TITLE
Fixes hardcoded LB IP address pool

### DIFF
--- a/src/terraform/templates/default-ipaddresspool.yaml.tftpl
+++ b/src/terraform/templates/default-ipaddresspool.yaml.tftpl
@@ -5,5 +5,5 @@ metadata:
   namespace: metallb
 spec:
   addresses:
-  - 10.26.3.0/24
+  - ${load_balancer_cidr}
 


### PR DESCRIPTION
TL;DR
-----

Repairs a defect where the specified balancer CIDR was ignored

Details
-------

Uses the expected parameter to set the CIDR for load balancer IPs.
In the current code the value is hardcodeed for the old CIDR
used for the ferret cluster so all clusters were getting that IP
range. Once this change is applied the parameter is used.
