### PR TITLE
Implements gVisor as an optional runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ control_plane_cidr	  = "$(shell yq .cluster.control_plane_cidr $(params_yaml))"
 control_plane_mac     = $(shell yq --output-format json .cluster.control_plane_mac $(params_yaml))
 load_balancer_cidr	  = "$(shell yq .cluster.load_balancer_cidr $(params_yaml))"
 
+enable_gvisor = "$(shell yq '.cluster.runtimes.gvisor.enabled // false' $(params_yaml))"
+
 vsphere_server    = "$(shell yq .vsphere.server $(params_yaml))"
 vsphere_username  = "$(shell yq .vsphere.username $(params_yaml))"
 vsphere_password  = "$(shell sops --decrypt --extract '["vsphere"]["password"]' $(params_yaml))"

--- a/manifests/runtimes/gvisor.yaml
+++ b/manifests/runtimes/gvisor.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: gvisor-installer
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k0s-app: gvisor-installer
+  template:
+    metadata:
+      labels:
+        k0s-app: gvisor-installer
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      initContainers:
+        - name: gvisor-installer
+          image: quay.io/k0sproject/k0s-gvisor-plugin:main
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: bin
+              mountPath: /var/lib/k0s/bin
+            - name: imports
+              mountPath: /etc/k0s/containerd.d/
+      containers:
+        # We need one dummy container as DaemonSet do not allow to
+        # run pods with restartPolicy other than Always ¯\_(ツ)_/¯
+        - name: dummy
+          image: registry.k8s.io/pause:3.6
+      volumes:
+        - name: bin
+          hostPath:
+            path: /var/lib/k0s/bin
+            type: Directory
+        - name: imports
+          hostPath:
+            path: /etc/k0s/containerd.d/
+            type: Directory
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: gvisor
+handler: runsc

--- a/src/terraform/cluster.tf
+++ b/src/terraform/cluster.tf
@@ -9,6 +9,8 @@ resource "local_sensitive_file" "k0sctl" {
                                 first_controller = vsphere_virtual_machine.control_plane.0.default_ip_address
                                 workers = [ for worker in vsphere_virtual_machine.worker : worker.default_ip_address ]
 
+                                enable_gvisor = var.enable_gvisor
+
                                 work_dir     = local.directories.work
                                 manifest_dir = local.directories.manifests
                             }

--- a/src/terraform/templates/k0sctl.tftpl
+++ b/src/terraform/templates/k0sctl.tftpl
@@ -55,6 +55,12 @@ spec:
       src: ${work_dir}/manifests/02-tailscale-proxy.yaml
       dstDir: /var/lib/k0s/manifests/tailscaled
       perm: 0600
+    %{ if enable_gvisor }
+    - name: gvisor.yaml
+      src: ${manifest_dir}/runtimes/gvisor.yaml
+      dstDir: /var/lib/k0s/manifests/runtimes
+      perm: 0600
+    %{ endif }
     %{ endif }
   %{ endfor }
   %{ for worker in workers }

--- a/src/terraform/variables.tf
+++ b/src/terraform/variables.tf
@@ -45,6 +45,11 @@ variable "load_balancer_cidr" {
 }
 
 
+variable "enable_gvisor" {
+  type = bool
+  default = false
+}
+
 variable "cpus" {
   type    = number
   default = 4


### PR DESCRIPTION
TL;DR
-----

Provides a gVisor runtime when `cluster.runtimes.gvisor.enabled`
is set to true

Details
-------

Uses the K0s gVisor installer to install the gVisor runtime and
create a runtime class for it. The installation is conditioned on
a variable in `secrets/params.yaml` being set to true.

To include gVisor in your cluster, add

```
cluster:
  runtimes:
    gvisor:
      enabled: true
```

to your parameters file.
