### PR TITLE
Implements wasm as an optional runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ control_plane_mac     = $(shell yq --output-format json .cluster.control_plane_m
 load_balancer_cidr	  = "$(shell yq .cluster.load_balancer_cidr $(params_yaml))"
 
 enable_gvisor = "$(shell yq '.cluster.runtimes.gvisor.enabled // false' $(params_yaml))"
+enable_wasm = "$(shell yq '.cluster.runtimes.wasm.enabled // false' $(params_yaml))"
 
 vsphere_server    = "$(shell yq .vsphere.server $(params_yaml))"
 vsphere_username  = "$(shell yq .vsphere.username $(params_yaml))"

--- a/manifests/runtimes/wasmtime-spin.yaml
+++ b/manifests/runtimes/wasmtime-spin.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: wasm-enabler
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k0s-app: wasm-enabler
+  template:
+    metadata:
+      labels:
+        k0s-app: wasm-enabler
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: plugin.k0sproject.io/wasm-enabled
+                    operator: DoesNotExist
+      initContainers:
+        - name: wasm-enabler
+          image: quay.io/k0sproject/k0s-wasm-plugin:main
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: bin
+              mountPath: /var/lib/k0s/bin
+            - name: imports
+              mountPath: /etc/k0s/containerd.d/
+      containers:
+        - name: dummy
+          image: registry.k8s.io/pause:3.6
+      volumes:
+        - name: bin
+          hostPath:
+            path: /var/lib/k0s/bin
+            type: Directory
+        - name: imports
+          hostPath:
+            path: /etc/k0s/containerd.d/
+            type: Directory
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: wasmtime-spin
+handler: spin

--- a/src/terraform/cluster.tf
+++ b/src/terraform/cluster.tf
@@ -10,6 +10,7 @@ resource "local_sensitive_file" "k0sctl" {
                                 workers = [ for worker in vsphere_virtual_machine.worker : worker.default_ip_address ]
 
                                 enable_gvisor = var.enable_gvisor
+                                enable_wasm = var.enable_wasm
 
                                 work_dir     = local.directories.work
                                 manifest_dir = local.directories.manifests

--- a/src/terraform/templates/k0sctl.tftpl
+++ b/src/terraform/templates/k0sctl.tftpl
@@ -61,6 +61,12 @@ spec:
       dstDir: /var/lib/k0s/manifests/runtimes
       perm: 0600
     %{ endif }
+    %{ if enable_wasm }
+    - name: wasmtime-spin.yaml
+      src: ${manifest_dir}/runtimes/wasmtime-spin.yaml
+      dstDir: /var/lib/k0s/manifests/runtimes
+      perm: 0600
+    %{ endif }
     %{ endif }
   %{ endfor }
   %{ for worker in workers }

--- a/src/terraform/variables.tf
+++ b/src/terraform/variables.tf
@@ -44,8 +44,12 @@ variable "load_balancer_cidr" {
   type = string
 }
 
-
 variable "enable_gvisor" {
+  type = bool
+  default = false
+}
+
+variable "enable_wasm" {
   type = bool
   default = false
 }


### PR DESCRIPTION
TL;DR
-----

Provides a wasm runtime when `cluster.runtimes.wasm.enabled`
is set to true

Details
-------

Uses the K0s wasm enabler to install a wasm runtime and
create a runtime class for it. The installation is conditioned on
a variable in `secrets/params.yaml` being set to true.

To include wasm in your cluster, add

```
cluster:
  runtimes:
    wasm:
      enabled: true
```

to your parameters file.
