### PR TITLE
Updates to K8s 1.29

### DIFF
--- a/src/terraform/templates/k0sctl.tftpl
+++ b/src/terraform/templates/k0sctl.tftpl
@@ -76,7 +76,7 @@ spec:
     role: worker
   %{ endfor }
   k0s:
-    version: 1.28.6+k0s.0
+    version: 1.29.1+k0s.0
     dynamicConfig: false
     config:
       apiVersion: k0s.k0sproject.io/v1beta1


### PR DESCRIPTION
TL;DR
-----

Bumps K0s version to the latest 1.29.1

Details
-------

Updates the K0s configuration template to use the latest release
of Kubernets, version 1.29.1.
