### PR TITLE
Updates vCenter key thumbprint

### DIFF
--- a/src/terraform/templates/csi-vsphere.conf.tftpl
+++ b/src/terraform/templates/csi-vsphere.conf.tftpl
@@ -1,7 +1,7 @@
 [Global]
 cluster-id = ${cluster_id}
 cluster-distribution = "k0s"
-thumbprint = "B1:9E:E0:F5:F6:C6:01:AA:25:91:0E:5F:04:06:D7:3A:D6:8D:70:1A"
+thumbprint = "CF:BF:0E:CD:0B:57:7E:B1:7A:6D:04:05:84:E8:89:5A:8B:F3:51:9E"
 
 [VirtualCenter "vcenter.lab.shortrib.net"]
 insecure-flag = false


### PR DESCRIPTION
TL;DR
-----

Assures the right thumbprint for the vCenter certificate

Details
-------

The vSphere CSI stopped working on my clusters after I rotated the
certificate for vCenter. This change updates the thumbprint in the
template the creates the vSphere CSI configuration secret so that it
can properly validate the connection when the server presents the new
certificate.
