### PR TITLE
Bumps k0s version

### DIFF
--- a/src/terraform/templates/k0sctl.tftpl
+++ b/src/terraform/templates/k0sctl.tftpl
@@ -76,7 +76,7 @@ spec:
     role: worker
   %{ endfor }
   k0s:
-    version: 1.29.1+k0s.0
+    version: 1.29.4+k0s.0
     dynamicConfig: false
     config:
       apiVersion: k0s.k0sproject.io/v1beta1


### PR DESCRIPTION
TL;DR
-----

Upgrades to Kubernets 1.29.4

Details
-------

Updates the configuration for `k0sctl` to use the latest version of
k0s, version 1.29.4+k0s.0.
