### PR TITLE
Establishes Kubernetes access over my Tailnet

### DIFF
--- a/manifests/tailscale/00-authproxy-rbac.yaml
+++ b/manifests/tailscale/00-authproxy-rbac.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) Tailscale Inc & AUTHORS
+# SPDX-License-Identifier: BSD-3-Clause
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tailscale-auth-proxy
+rules:
+- apiGroups: [""]
+  resources: ["users", "groups"]
+  verbs: ["impersonate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tailscale-auth-proxy
+subjects:
+- kind: ServiceAccount
+  name: operator
+  namespace: tailscale
+roleRef:
+  kind: ClusterRole
+  name: tailscale-auth-proxy
+  apiGroup: rbac.authorization.k8s.io

--- a/src/terraform/templates/k0sctl.tftpl
+++ b/src/terraform/templates/k0sctl.tftpl
@@ -119,6 +119,8 @@ spec:
                 oauth:
                   clientId: ${tailscale_client_id}
                   clientSecret: ${tailscale_client_secret}
+                apiServerProxyConfig:
+                  mode: "true"
               order: 10
             - name: projectcontour
               chartname: oci://index.docker.io/bitnamicharts/contour


### PR DESCRIPTION
TL;DR
-----

Prepares the Kubernetes cluster and operator for access via Tailscale
authentication over my Tailnet

Details
-------

Provides the proper RBAC configuration and Tailscale Opertor
configuration to expose the Kubernetes API over the tailnet with
Tailscale providing authentication. This enable reducing the number of
exposed routes from the Homelab to the Tailnet.
