### PR TITLE
Adds Tailscale access to kubeconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ cluster: nodes
 	@sops --decrypt ${SECRETS_DIR}/tailscale-authkey.yaml > ${WORK_DIR}/manifests/01-tailscale-authkey.yaml
 	@k0sctl apply --config ${SECRETS_DIR}/k0sctl.yaml
 	@k0sctl kubeconfig --config ${SECRETS_DIR}/k0sctl.yaml > ${SECRETS_DIR}/kubeconfig
+	@export KUBECONFIG=${SECRETS_DIR}/kubeconfig
+	@tailscale configure kubeconfig $(cluster_name)-operator
+	@yq -i '.contexts[] |= (select(.name == "$(cluster_name)-operator.walrus-shark.ts.net").name = "tailscale-auth@$(cluster_name)" // .) | .contexts[] |= (select(.name == "$(cluster_name)").name = "$(cluster_name)-admin@$(cluster_name)" // .) | .contexts[] |= (select(.context.user == "admin").context.user = "$(cluster_name)-admin" // .) | .users[] |= (select(.name == "admin").name = "$(cluster_name)-admin" // .) | .current-context = "$(cluster_name)-admin"' ${SECRETS_DIR}/kubeconfig
 	@rm -rf work/manifests
 
 .PHONY: test


### PR DESCRIPTION
TL;DR
-----

Includes a tailscale context in the kubeconfig

Details
-------

Updates the `Makefile` to add connection via Tailscale to the
kubeconfig we generate. Also renames the contexts and users so that
different cluster kubeconfigs can more easily be combined. What I used
to do by hand to edit them is now automated at build time.
