### PR TITLE
Correcst SOPS encryption for tailscale

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,6 +1,6 @@
 creation_rules:
 - path: secrets/params.yaml
-  encrypted_regex: '^(password|api-key|default_password)$'
+  encrypted_regex: '^(password|api-key|default_password|client_secret)$'
   pgp: 905EBD494A6AA2B774ED5C67621620CDA290611D
 - path: base/capv-system
   encrypted_regex: '^(VSPHERE_USERNAME|VSPHERE_PASSWORD)$'


### PR DESCRIPTION
TL;DR
-----

Closes massive security hole that exposed tailscale creentials

Details
-------

Reconfigures SOPS to encrypt the tailscale credentials. The old ones are
revoked.
