### PR TITLE
TL;DR -----

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.worktrees
 secrets/*
 !secrets/params.yaml
 work/*


### PR DESCRIPTION
Ignores worktree directory

Details
-------

Adds the .worktrees directory to the .gitignore file because
worktrees are pretty perfect for how I work with this repo.
