### PR TITLE
Repairs tailscale in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,9 @@ nodes: $(tfvars)
 cluster: nodes
 	@mkdir -p work/manifests
 	@sops --decrypt ${SECRETS_DIR}/cloudflare-api-token.yaml > ${WORK_DIR}/manifests/01-cloudflare-api-token.yaml
-	@sops --decrypt ${SECRETS_DIR}/tailscale-authkey.yaml > ${WORK_DIR}/manifests/01-tailscale-authkey.yaml
 	@k0sctl apply --config ${SECRETS_DIR}/k0sctl.yaml
 	@k0sctl kubeconfig --config ${SECRETS_DIR}/k0sctl.yaml > ${SECRETS_DIR}/kubeconfig
-	@export KUBECONFIG=${SECRETS_DIR}/kubeconfig
-	@tailscale configure kubeconfig $(cluster_name)-operator
+	@export KUBECONFIG=${SECRETS_DIR}/kubeconfig && tailscale configure kubeconfig $(cluster_name)-operator
 	@yq -i '.contexts[] |= (select(.name == "$(cluster_name)-operator.walrus-shark.ts.net").name = "tailscale-auth@$(cluster_name)" // .) | .contexts[] |= (select(.name == "$(cluster_name)").name = "$(cluster_name)-admin@$(cluster_name)" // .) | .contexts[] |= (select(.context.user == "admin").context.user = "$(cluster_name)-admin" // .) | .users[] |= (select(.name == "admin").name = "$(cluster_name)-admin" // .) | .current-context = "$(cluster_name)-admin@$(cluster_name)"' ${SECRETS_DIR}/kubeconfig
 	@rm -rf work/manifests
 


### PR DESCRIPTION
TL;DR
-----

Gets Makefile working for cluster Tailscale

Details
-------

Catches the Makefile up with the changes to how I'm using
Tailscale. The `kubeconfig` call is now combined with setting
the `KUBECONFIG` for Tailscale to assure the correct file is
updated, and the old manifest for the auth key is not longer used.
