### PR TITLE
Bumps Kubernetes

### DIFF
--- a/src/terraform/templates/k0sctl.tftpl
+++ b/src/terraform/templates/k0sctl.tftpl
@@ -60,7 +60,7 @@ spec:
     role: worker
   %{ endfor }
   k0s:
-    version: 1.33.1+k0s.1
+    version: 1.34.2+k0s.0
     dynamicConfig: false
     config:
       apiVersion: k0s.k0sproject.io/v1beta1


### PR DESCRIPTION
TL;DR
-----

Uses Kubernetes 1.34

Details
-------

Updates the k0sctl configuration to use the lastest version of
Kubernetes available from K0s (`1.34.2+k0s.0`).
