### PR TITLE
Swaps Traefik in for Contour

### DIFF
--- a/src/terraform/templates/k0sctl.tftpl
+++ b/src/terraform/templates/k0sctl.tftpl
@@ -136,7 +136,7 @@ spec:
                 apiServerProxyConfig:
                   mode: "true"
               order: 10
-            - name: projectcontour
-              chartname: oci://index.docker.io/bitnamicharts/contour
-              namespace: projectcontour
+            - name: traefik
+              chartname: oci://ghcr.io/traefik/helm/traefik
+              namespace: traefik
               order: 20


### PR DESCRIPTION
TL;DR
-----

Switches the Kubernetes ingress controller from Bitnami's Contour to Traefik for ongoing support

Details
--------

Moves from Contour to Traefik. We were using the Bitnami chart for Contour and that was a deadend, as is Ingress NGINX. In the end I stuck with Contour because I was fond of it from the Tanzu days. Traefik has a lot to offer, and it's getting a lot of attention with Ingress NGINX going away. Updates the Helm chart configuration in the k0sctl template, pulling Traefik directly from its official OCI registry at GitHub Container Registry. To follow Traefik's conventional deployment patterns, the namespace shifts from `projectcontour` to `traefik`.
