### PR TITLE
Bumps Kubernetes to 1.35

### DIFF
--- a/src/terraform/templates/k0sctl.tftpl
+++ b/src/terraform/templates/k0sctl.tftpl
@@ -60,7 +60,7 @@ spec:
     role: worker
   %{ endfor }
   k0s:
-    version: 1.34.2+k0s.0
+    version: 1.35.2+k0s.0
     dynamicConfig: false
     config:
       apiVersion: k0s.k0sproject.io/v1beta1


### PR DESCRIPTION
TL;DR
-----

Upgrades k0s to 1.35.2.

Details
-------

Moves to Kuberntes 1.35.x using K0s 1.35.2+k0s.0. This is a change to
the `k0sctl` template.
