### PR TITLE
Configures k0sctl to use sudo for privilege escalation

### DIFF
--- a/src/terraform/templates/k0sctl.tftpl
+++ b/src/terraform/templates/k0sctl.tftpl
@@ -8,6 +8,9 @@ spec:
   - ssh:
       address: ${controller}
       user: ${user}
+    os:
+      override:
+        becomePrivileged: true
     role: controller+worker
     %{ if controller == first_controller }
     files:
@@ -57,6 +60,9 @@ spec:
   - ssh:
       address: ${worker}
       user: ${user}
+    os:
+      override:
+        becomePrivileged: true
     role: worker
   %{ endfor }
   k0s:


### PR DESCRIPTION
## Summary

- Adds `os.override.becomePrivileged: true` to k0sctl host configurations
- Enables k0sctl to use sudo instead of requiring direct root SSH access
- Required for compatibility with the SSH hardening in #36 which disables root login

## Changes

Updates `k0sctl.tftpl` to add the `becomePrivileged` option to both controller and worker host definitions.

## Test plan

- [ ] Run `k0sctl apply` and verify it successfully connects and installs/updates the cluster
- [ ] Verify k0sctl operations work with the non-root user + sudo

🤖 Generated with [Claude Code](https://claude.com/claude-code)