### PR TITLE
Upgrades to Ubuntu 25.04 (Plucky) for OpenSSH 9.9

### DIFF
--- a/secrets/REDACTED-params.yaml
+++ b/secrets/REDACTED-params.yaml
@@ -3,7 +3,7 @@
 hostname: node
 domain: lab.shortrib.net # replace with your domain
 
-remote_ovf_url: https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
+remote_ovf_url: https://cloud-images.ubuntu.com/plucky/current/plucky-server-cloudimg-amd64.img
 
 default_password: REDACTED # password for the default `ubuntu` user
 

--- a/secrets/params.yaml
+++ b/secrets/params.yaml
@@ -1,7 +1,7 @@
 cluster_name: opossum
 domain: lab.shortrib.net
-remote_ovf_url: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.ova
-default_password: ENC[AES256_GCM,data:J7CwEwI6VAu/kdESOJ0wcturasHbTVcCzA==,iv:xyaR3nbyhZHMOkdLqWyAh2W11Rr0Qct8AJDCDVVWYvk=,tag:oo4q3kvvwXp5PDLnmhfBuw==,type:str]
+remote_ovf_url: https://cloud-images.ubuntu.com/plucky/current/plucky-server-cloudimg-amd64.ova
+default_password: ENC[AES256_GCM,data:lIstIgxRFlGse8dkpoxDc7UZ1SSb6mrZbQ==,iv:VAgDoheNpEQH5QZciK0zKgLwb/IIDxPDpJBElzlyRxo=,tag:T3k2GcRY9BZNKCDsyyERBA==,type:str]
 ssh:
     authorized_keys:
         - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILsWPxOAWaavdJo6Itgp2VXyCeQqAA4thIzuY8uxxTI1 cardno:20_890_576
@@ -32,7 +32,7 @@ node:
 vsphere:
     server: vcenter.lab.shortrib.net
     username: terraform@shortrib.local
-    password: ENC[AES256_GCM,data:Eu1hAvzlpibzYTFKJL35UowVnA==,iv:gyTeoc8eT1d889yGEXgcOOEWZ+6A4OygGySlqXXTzQ4=,tag:OMg56gWoppKikMldfZ+DzA==,type:str]
+    password: ENC[AES256_GCM,data:XLszyw+jxUvlGAGgEnIPyH9VMw==,iv:eR9m9l3J9LJmFrpWJSF6H9EbAeeGlF8HXlhICYzzqdg=,tag:cHMsBCthYBZuC3y6coO2nA==,type:str]
     datacenter: garage
     cluster: homelab
     host: rye.lab.shortrib.net
@@ -42,25 +42,24 @@ vsphere:
     datastore: vsanDatastore
     folder: clusters
 cloudflare:
-    api-key: ENC[AES256_GCM,data:ruYdqOc4fjM/lUV4vFTKNiTfkykfjLhMo4os0qLmxogPF7gydw==,iv:4Ix1lfN6EVAUntBC8NOlAzfywUDKqMjY5KvWDkk0nxM=,tag:+E4oe8XQPqiOPQP7YQysIA==,type:str]
+    api-key: ENC[AES256_GCM,data:hBnFHrJzkadOXCEioWShdbe/+BHo8eSA4fNnIPZBOyo7eso40A==,iv:jB3PiHAx+1OfTogqNB8aT6uaUG1yuxKPxcGejNeDUOI=,tag:v95zhM4lRmFRg4csCshe9Q==,type:str]
 tailscale:
     client_id: kZzRH1J7hX11CNTRL
-    client_secret: tskey-client-kZzRH1J7hX11CNTRL-JwRwVA8LUF3aDv8AcpwML31JirayzUqZ
+    client_secret: ENC[AES256_GCM,data:6T1pARbEiW9AdXtD8H4FK1R32XO7umU5RYNDoCep/ipsyJkHYirwDC5ZKT9NBt0e4+j0ATo5bAG9jBZs+qNs,iv:iOFJCX2loXTJBDdSYoCwprLY8AsxwhQ5DzWLO70xpuY=,tag:f7cwaeLn7cYOCpLm2FDwBA==,type:str]
 sops:
-    lastmodified: "2025-06-21T13:17:02Z"
-    mac: ENC[AES256_GCM,data:mCWyKD2fy1uopDocRjcwFLT3n0MzxvEHdUcxI/L9ouklt9fZ+vMunl2lBnjCI8Nzq9zGghcd+e7qfHs7o0C+OhKhN7q1VftqeixT8vHUpX90Cw3cHTub0Gg8SmsDMrFS/yZvSs+TTKg5EmVSASwEUb5M95ynBheJsgIt1HHNEuE=,iv:ifid/Aba9rfYLyd/Q2U+NJl69/MHyUs0kooewTFLjck=,tag:AFkLf26J5DfFtBEsm27OiA==,type:str]
+    lastmodified: "2026-04-13T18:16:32Z"
+    mac: ENC[AES256_GCM,data:IqLzmetoRRoISBQWffPf5pvp0G8687VFLCD5QYqb/tMIwgRXGdxjtGNeaGD4XAu+Zek3gHfLqv4SOI6soUInf5dVcbFqiwMyDormxmuX1QHv40IPEjv+DCfLo1xomMl7IJueaT5l+E2QmRN6GNy2DWyybaFO2W/DXlPar1JGp7g=,iv:KgaMtT5CNG0BPasChtoStGfFI0wucZtIvVJE19LDG7Y=,tag:R2kpeIqiB1+94q2Tn7qPvQ==,type:str]
     pgp:
-        - created_at: "2023-07-12T03:38:24Z"
-          enc: |
+        - created_at: "2026-04-13T18:16:32Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hF4DYhYgzaKQYR0SAQdAd+k72h1mVci/fHyBGfMmH+5aEHT8Ji6/PWkxBZ+ic3Iw
-            qjOkev3WEkEL1/G/2BA5cTx9eL3BoBTqXk/LSqHEd/uCAAr5Afi+kPCUMrIFIbL3
-            1GgBCQIQ4sdqcbewDEu8BA7X+AbwidOrwF+2qxBAqMPAS2FdxIUrLpLAW+f0jUc4
-            FZ9hnQD/M+GVRLA1/w+tSy7WXYTo7ePOiLM7cRsD6ZE0k+zWTf7TN/JHQ7Kqm7RD
-            oJx4wxsLmE45yg==
-            =3Sqn
+            hF4DYhYgzaKQYR0SAQdAn23WeUrIIKJV90hT6XyLAcMolhSv0o/VVxN211+NtDgw
+            5fwUbXG5RaHBINlic4PFz3FX6KMrsKSbRP7VxoagfBjUivL5lGie337RN6UWt6lx
+            0l4BCMQFY3Q3Y+6KGAITWUBFt8xWHJmGh04PcLPdS5qUbN/sw2t2pC0u2U81bKF0
+            dETv4JQEG3s7jlAdu5lpnHUwwj5nWhX8sz2iXt8tvmUY8jWiXrdSS2x+tLv8bBSH
+            =Q10G
             -----END PGP MESSAGE-----
           fp: 905EBD494A6AA2B774ED5C67621620CDA290611D
-    encrypted_regex: ^(password|api-key|default_password)$
-    version: 3.10.2
+    encrypted_regex: ^(password|api-key|default_password|client_secret)$
+    version: 3.11.0

--- a/src/terraform/main.tf
+++ b/src/terraform/main.tf
@@ -28,6 +28,7 @@ locals {
     {
       ssh_authorized_keys = yamlencode(var.ssh_authorized_keys)
       users               = yamlencode(local.users)
+      user                = local.users.1.name
     }
   )
 }

--- a/src/terraform/templates/user-data.tftpl
+++ b/src/terraform/templates/user-data.tftpl
@@ -199,12 +199,12 @@ write_files:
 
 ### Run arbitrary commands at boot time
 runcmd:
-- [ chsh, -s, /usr/bin/zsh, crdant ]
+- [ chsh, -s, /usr/bin/zsh, ${user} ]
 - echo "# limit who can use SSH\nAllowGroups ssher" > /etc/ssh/sshd_config.d/02-limit-to-ssher.conf
 - netplan apply
 # Add cloud user to ssher group so they can SSH in
 - |
-  for user in ubuntu crdant ec2-user cloud-user admin; do
+  for user in ubuntu ${user} ec2-user cloud-user admin; do
     if id "$user" &>/dev/null; then
       usermod -aG ssher "$user"
       echo "[harden-ssh] Added $user to ssher group"


### PR DESCRIPTION
## Summary

- Upgrades base cloud image from Ubuntu 22.04 (Jammy) to Ubuntu 25.04 (Plucky)
- Fixes hardcoded username references in user-data template

## Why

The SSH hardening from #36 uses the `mlkem768x25519-sha256` post-quantum key exchange algorithm, which requires OpenSSH 9.9+. Ubuntu Jammy/Noble ship OpenSSH 9.6, causing sshd to fail on startup with an invalid algorithm error.

Ubuntu 25.04 (Plucky) ships OpenSSH 9.9p1 which supports the full post-quantum configuration.

## Changes

1. **params.yaml** - Updated `remote_ovf_url` to Plucky cloud image
2. **REDACTED-params.yaml** - Updated example URL to Plucky
3. **main.tf** - Added `user` variable to user-data template
4. **user-data.tftpl** - Replaced hardcoded `crdant` with `${user}` variable

## Test plan

- [x] Deployed VM with Plucky image and SSH hardening - SSH works
- [ ] Verify `k0sctl apply` works with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)