### PR TITLE
Uses cluster_image_name instead of remote_ovf_url

### DIFF
--- a/secrets/REDACTED-params.yaml
+++ b/secrets/REDACTED-params.yaml
@@ -3,7 +3,7 @@
 hostname: node
 domain: lab.shortrib.net # replace with your domain
 
-remote_ovf_url: https://cloud-images.ubuntu.com/plucky/current/plucky-server-cloudimg-amd64.img
+cluster_image_name: ubuntu-25.04-server-cloudimg-amd64.img
 
 default_password: REDACTED # password for the default `ubuntu` user
 

--- a/secrets/params.yaml
+++ b/secrets/params.yaml
@@ -1,7 +1,7 @@
 cluster_name: opossum
 domain: lab.shortrib.net
-remote_ovf_url: https://cloud-images.ubuntu.com/plucky/current/plucky-server-cloudimg-amd64.ova
-default_password: ENC[AES256_GCM,data:lIstIgxRFlGse8dkpoxDc7UZ1SSb6mrZbQ==,iv:VAgDoheNpEQH5QZciK0zKgLwb/IIDxPDpJBElzlyRxo=,tag:T3k2GcRY9BZNKCDsyyERBA==,type:str]
+cluster_image_name: ubuntu-25.04-server-cloudimg-amd64.img
+default_password: ENC[AES256_GCM,data:rtzmsjaN77yamT8avEAKLtEKKS+nwsr0tA==,iv:itDiboRWklClSE3GRqNbpAZ1W62TBBuKKOncSI4qX7A=,tag:ffDjIhg6FTRMbpnbDhfQZQ==,type:str]
 ssh:
     authorized_keys:
         - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILsWPxOAWaavdJo6Itgp2VXyCeQqAA4thIzuY8uxxTI1 cardno:20_890_576
@@ -32,7 +32,7 @@ node:
 vsphere:
     server: vcenter.lab.shortrib.net
     username: terraform@shortrib.local
-    password: ENC[AES256_GCM,data:XLszyw+jxUvlGAGgEnIPyH9VMw==,iv:eR9m9l3J9LJmFrpWJSF6H9EbAeeGlF8HXlhICYzzqdg=,tag:cHMsBCthYBZuC3y6coO2nA==,type:str]
+    password: ENC[AES256_GCM,data:k1Jj9AmwWJzGPzICA2T7RmntBg==,iv:5w6PlYBO4chTVB8OuIXkOEcjv39P8x5sG/1Um4gGkxE=,tag:nqHx85Z6sToTFiTYrBWbxA==,type:str]
     datacenter: garage
     cluster: homelab
     host: rye.lab.shortrib.net
@@ -42,23 +42,23 @@ vsphere:
     datastore: vsanDatastore
     folder: clusters
 cloudflare:
-    api-key: ENC[AES256_GCM,data:hBnFHrJzkadOXCEioWShdbe/+BHo8eSA4fNnIPZBOyo7eso40A==,iv:jB3PiHAx+1OfTogqNB8aT6uaUG1yuxKPxcGejNeDUOI=,tag:v95zhM4lRmFRg4csCshe9Q==,type:str]
+    api-key: ENC[AES256_GCM,data:ZYaVIp+b9ooJrcCscKsjmSkEmVMSAwCSsGwRAJp7qFeDBxEE4w==,iv:KBiWOO/YArS5MXJPaP9R/DhXC01krhICDF9XQA+KFOQ=,tag:tTSdKkmCbLvYAqkT9/yZkA==,type:str]
 tailscale:
     client_id: kZzRH1J7hX11CNTRL
-    client_secret: ENC[AES256_GCM,data:6T1pARbEiW9AdXtD8H4FK1R32XO7umU5RYNDoCep/ipsyJkHYirwDC5ZKT9NBt0e4+j0ATo5bAG9jBZs+qNs,iv:iOFJCX2loXTJBDdSYoCwprLY8AsxwhQ5DzWLO70xpuY=,tag:f7cwaeLn7cYOCpLm2FDwBA==,type:str]
+    client_secret: ENC[AES256_GCM,data:Bza25E54h5pRbx8RFycJs6lZjZlS2qm8R9xOFwqPoY/fy0M2t/FPuMxGqwgg3nMZ8XRJi9KzFAmnqhi6qO9s,iv:/fdoGaTi7LjgfIZMsK7OSFN+AAVPABfHiHXpNxKMxY0=,tag:5V1rdqNVHJm+29xuDrjmgA==,type:str]
 sops:
-    lastmodified: "2026-04-13T18:16:32Z"
-    mac: ENC[AES256_GCM,data:IqLzmetoRRoISBQWffPf5pvp0G8687VFLCD5QYqb/tMIwgRXGdxjtGNeaGD4XAu+Zek3gHfLqv4SOI6soUInf5dVcbFqiwMyDormxmuX1QHv40IPEjv+DCfLo1xomMl7IJueaT5l+E2QmRN6GNy2DWyybaFO2W/DXlPar1JGp7g=,iv:KgaMtT5CNG0BPasChtoStGfFI0wucZtIvVJE19LDG7Y=,tag:R2kpeIqiB1+94q2Tn7qPvQ==,type:str]
+    lastmodified: "2026-04-13T18:33:27Z"
+    mac: ENC[AES256_GCM,data:tWxMMHbMF5LrEUmWOx0JDGBEYd6zyYZ2bgrK8E2yAJ6zO+e44hKmo47mTajdgHAwmQb+IwKj+jOJeQvKaDhMU+TbJoJtDR59LmstdfjeYd/mu++spIGhoh8dW37fYbq2aXnxNOZ7cw/kiX3FfvB4xY+GwwOT0Bp0G6oRbAsqTyE=,iv:3wlkWBtaFljybYk9cEgurvrzrZfZLVCtInx6/fnixng=,tag:RZ3t6Hc65QDxt6ZwB1ydJQ==,type:str]
     pgp:
-        - created_at: "2026-04-13T18:16:32Z"
+        - created_at: "2026-04-13T18:33:27Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hF4DYhYgzaKQYR0SAQdAn23WeUrIIKJV90hT6XyLAcMolhSv0o/VVxN211+NtDgw
-            5fwUbXG5RaHBINlic4PFz3FX6KMrsKSbRP7VxoagfBjUivL5lGie337RN6UWt6lx
-            0l4BCMQFY3Q3Y+6KGAITWUBFt8xWHJmGh04PcLPdS5qUbN/sw2t2pC0u2U81bKF0
-            dETv4JQEG3s7jlAdu5lpnHUwwj5nWhX8sz2iXt8tvmUY8jWiXrdSS2x+tLv8bBSH
-            =Q10G
+            hF4DYhYgzaKQYR0SAQdATc4NQ0OPYrkOVInWiFg+ct9Bgn7S48re5iwa3RHyBwww
+            iPAHLLSg1i96ZbzdjqjH7uMAiFw6gxzPGEggvZG/Ge3M3nOZ7kxDx2AnQF8hAm9I
+            0lwBr7zDrqrv/dBbjKETza9Dn/4w3044hTlg4rIav802hlLpuTYPUN2VA8EebJ47
+            AxVda4D0zcv+VoG4tDTq63U+fBqRWXf6736rTKNxG6NX19udubx/tGOkYSlcWw==
+            =J8OB
             -----END PGP MESSAGE-----
           fp: 905EBD494A6AA2B774ED5C67621620CDA290611D
     encrypted_regex: ^(password|api-key|default_password|client_secret)$


### PR DESCRIPTION
## Summary

References the pre-uploaded Nutanix image by name rather than downloading from a URL, consistent with other cluster configurations (e.g., ferret).

## Changes

- Replaces `remote_ovf_url` with `cluster_image_name: ubuntu-25.04-server-cloudimg-amd64.img`

🤖 Generated with [Claude Code](https://claude.com/claude-code)