### PR TITLE
Configures git diff driver for SOPS encrypted files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.enc diff=secrets
+secrets/*.yaml diff=sops
+secrets/REDACTED-*.yaml diff


### PR DESCRIPTION
TL;DR
-----

Adds transparent git diff support for SOPS-encrypted secrets files.

Details
-------

Configures `.gitattributes` to use a sops diff driver for `secrets/*.yaml` files, showing decrypted content in diffs. REDACTED files use standard diff.

Requires local setup (one-time):
```bash
git config diff.sops.textconv "sops --decrypt"
```