### PR TITLE
Configures Nutanix Files storage class for RWX volumes

### DIFF
--- a/secrets/REDACTED-params.yaml
+++ b/secrets/REDACTED-params.yaml
@@ -43,6 +43,10 @@ nutanix:
   password: REDACTED                      # Will be SOPS-encrypted
   cluster: homelab                        # Nutanix cluster name
   storage_container: kubernetes           # Storage container for VMs
+  file_server: fileserver                 # Nutanix Files server name (as registered in Prism)
+  file_server_fqdn: fileserver.domain.com # Nutanix Files server FQDN (for REST API auth)
+  file_server_username: node              # Files server REST API user - use cluster name (create via Prism > File Server > Manage roles)
+  file_server_password: REDACTED          # Files server REST API password
   subnets:
     kubernetes: Kubernetes                # Management network subnet
     workload: Workload                    # Workload network subnet

--- a/src/terraform/cluster.tf
+++ b/src/terraform/cluster.tf
@@ -34,10 +34,13 @@ resource "local_sensitive_file" "user-data" {
 
 resource "local_sensitive_file" "nutanix_csi_secret" {
   content = templatefile("${local.directories.templates}/nutanix-csi-secret.yaml.tftpl", {
-    prism_endpoint    = var.nutanix_prism_central
-    nutanix_username  = var.nutanix_username
-    nutanix_password  = var.nutanix_password
-    storage_container = var.nutanix_storage_container
+    prism_endpoint       = var.nutanix_prism_central
+    nutanix_username     = var.nutanix_username
+    nutanix_password     = var.nutanix_password
+    storage_container    = var.nutanix_storage_container
+    file_server_fqdn     = var.nutanix_file_server_fqdn
+    file_server_username = var.nutanix_file_server_username
+    file_server_password = var.nutanix_file_server_password
   })
   filename        = "${local.directories.work}/manifests/01-nutanix-csi-secret.yaml"
   file_permission = "0600"
@@ -48,6 +51,14 @@ resource "local_sensitive_file" "nutanix_storageclass" {
     storage_container = var.nutanix_storage_container
   })
   filename        = "${local.directories.work}/manifests/02-nutanix-storageclass.yaml"
+  file_permission = "0600"
+}
+
+resource "local_sensitive_file" "nutanix_files_storageclass" {
+  content = templatefile("${local.directories.templates}/nutanix-files-storageclass.yaml.tftpl", {
+    file_server = var.nutanix_file_server
+  })
+  filename        = "${local.directories.work}/manifests/03-nutanix-files-storageclass.yaml"
   file_permission = "0600"
 }
 

--- a/src/terraform/templates/nutanix-csi-secret.yaml.tftpl
+++ b/src/terraform/templates/nutanix-csi-secret.yaml.tftpl
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ntnx-secret
+  name: ntnx-pc-secret
   namespace: kube-system
 stringData:
   # Format: prism-ip:prism-port:username:password
@@ -12,3 +12,5 @@ stringData:
   password: ${nutanix_password}
   storage-container: ${storage_container}
   service: volume
+  # Nutanix Files credentials - format: fileserver-fqdn:username:password
+  files-key: ${file_server_fqdn}:${file_server_username}:${file_server_password}

--- a/src/terraform/templates/nutanix-files-storageclass.yaml.tftpl
+++ b/src/terraform/templates/nutanix-files-storageclass.yaml.tftpl
@@ -1,20 +1,18 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: nutanix-volume
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+  name: nutanix-files
 provisioner: csi.nutanix.com
 parameters:
+  storageType: NutanixFiles
+  nfsServerName: ${file_server}
+  dynamicProv: ENABLED
+  squashType: root-squash
   csi.storage.k8s.io/provisioner-secret-name: ntnx-pc-secret
   csi.storage.k8s.io/provisioner-secret-namespace: kube-system
   csi.storage.k8s.io/node-publish-secret-name: ntnx-pc-secret
   csi.storage.k8s.io/node-publish-secret-namespace: kube-system
   csi.storage.k8s.io/controller-expand-secret-name: ntnx-pc-secret
   csi.storage.k8s.io/controller-expand-secret-namespace: kube-system
-  csi.storage.k8s.io/fstype: ext4
-  storageContainer: ${storage_container}
-  storageType: NutanixVolumes
-  flashMode: "DISABLED"
 allowVolumeExpansion: true
 reclaimPolicy: Delete

--- a/src/terraform/variables.tf
+++ b/src/terraform/variables.tf
@@ -93,6 +93,27 @@ variable "nutanix_storage_container" {
   description = "Storage container for VM disks"
 }
 
+variable "nutanix_file_server" {
+  type        = string
+  description = "Nutanix Files server name for RWX storage"
+}
+
+variable "nutanix_file_server_fqdn" {
+  type        = string
+  description = "Nutanix Files server FQDN for CSI authentication"
+}
+
+variable "nutanix_file_server_username" {
+  type        = string
+  description = "Username for Nutanix Files server"
+}
+
+variable "nutanix_file_server_password" {
+  type        = string
+  sensitive   = true
+  description = "Password for Nutanix Files server"
+}
+
 variable "kubernetes_subnet" {
   type        = string
   description = "Nutanix subnet for Kubernetes management network"


### PR DESCRIPTION
TL;DR
-----

Adds Nutanix Files storage class for ReadWriteMany (RWX) persistent volumes with dynamic provisioning.

Details
--------

Enables dynamic provisioning of NFS-backed persistent volumes using Nutanix Files. The configuration requires understanding a key distinction in how the CSI driver authenticates:

**Authentication Architecture**

The Nutanix Files server runs its own REST API on port 9440, separate from Prism Central. The CSI driver connects directly to the Files server for share management, requiring dedicated API credentials created on the Files server itself (via Prism > File Server > Manage roles > REST API access user).

**Configuration Requirements**

Two separate identifiers are needed for the file server:
- `nfsServerName` in StorageClass: The Prism-registered name (e.g., `rickhouse`)
- `files-key` in Secret: The FQDN for API authentication (e.g., `rickhouse.shortrib.run:username:password`)

**New Variables**

- `nutanix_file_server` - File server name as registered in Prism
- `nutanix_file_server_fqdn` - FQDN for REST API authentication  
- `nutanix_file_server_username` - REST API user (created on Files server)
- `nutanix_file_server_password` - REST API password

**Other Changes**

- Renames CSI secret from `ntnx-secret` to `ntnx-pc-secret` for clarity
- Updates existing storage class to reference renamed secret