### PR TITLE
Adds Nutanix Files variables to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ nutanix_password = "$(shell sops --decrypt --extract '["nutanix"]["password"]' $
 nutanix_prism_central = "$(shell yq .nutanix.prism_central $(params_yaml))"
 nutanix_cluster_name = "$(shell yq .nutanix.cluster $(params_yaml))"
 nutanix_storage_container = "$(shell yq .nutanix.storage_container $(params_yaml))"
+nutanix_file_server = "$(shell yq .nutanix.file_server $(params_yaml))"
+nutanix_file_server_fqdn = "$(shell yq .nutanix.file_server_fqdn $(params_yaml))"
+nutanix_file_server_username = "$(shell yq .nutanix.file_server_username $(params_yaml))"
+nutanix_file_server_password = "$(shell sops --decrypt --extract '["nutanix"]["file_server_password"]' $(params_yaml))"
 kubernetes_subnet = "$(shell yq .nutanix.subnets.kubernetes $(params_yaml))"
 workload_subnet = "$(shell yq .nutanix.subnets.workload $(params_yaml))"
 


### PR DESCRIPTION
TL;DR
-----

Adds missing Makefile variables for Nutanix Files configuration.

Details
--------

Follow-up to #47 - the Makefile wasn't updated to extract the file server variables from params.yaml and pass them to terraform. This adds the four missing variables:

- `nutanix_file_server`
- `nutanix_file_server_fqdn`
- `nutanix_file_server_username`
- `nutanix_file_server_password` (SOPS-encrypted)