### PR TITLE
Completes Nutanix CSI configuration for Files support

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,6 +1,6 @@
 creation_rules:
 - path: secrets/params.yaml
-  encrypted_regex: '^(password|api-key|default_password|client_secret)$'
+  encrypted_regex: '^(.*password|api-key|client_secret)$'
   pgp: 905EBD494A6AA2B774ED5C67621620CDA290611D
 - path: base/capv-system
   encrypted_regex: '^(VSPHERE_USERNAME|VSPHERE_PASSWORD)$'

--- a/src/terraform/templates/k0sctl.tftpl
+++ b/src/terraform/templates/k0sctl.tftpl
@@ -39,6 +39,11 @@ spec:
       src: ${manifest_dir}/acme/*
       dstDir: /var/lib/k0s/manifests/acme
       perm: 0600
+    - name: nutanix-files-storageclass
+      src: ${work_dir}/manifests/03-nutanix-files-storageclass.yaml
+      dstDir: /var/lib/k0s/manifests/nutanix-csi
+      perm: 0600
+      dirPerm: 0755
     %{ if enable_gvisor }
     - name: gvisor.yaml
       src: ${manifest_dir}/runtimes/gvisor.yaml
@@ -116,10 +121,10 @@ spec:
               values: |
                 storageClass:
                   enabled: true
-                prismEndPoint: ${nutanix_prism_central}
-                username: ${nutanix_username}
-                password: ${nutanix_password}
-                storageContainer: ${nutanix_storage_container}
+                createSecret: false
+                createPrismCentralSecret: false
+                createVolumeSnapshotClass: false
+                kubeletDir: /var/lib/k0s/kubelet
             - name: metallb
               chartname: metallb/metallb
               namespace: metallb

--- a/src/terraform/templates/user-data.tftpl
+++ b/src/terraform/templates/user-data.tftpl
@@ -26,6 +26,8 @@ packages:
 - zsh
 - neovim
 - jq
+- nfs-common
+- open-iscsi
 
 groups:
 - ssher
@@ -36,6 +38,15 @@ ${users}
 # Update apt database and upgrade packages on first boot
 package_update: true
 package_upgrade: true
+
+# Regenerate SSH host keys early (before sshd accepts connections)
+# Ed25519 + RSA-4096 only for security hardening
+bootcmd:
+- rm -f /etc/ssh/ssh_host_*key*
+- ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N "" -q
+- ssh-keygen -t rsa -b 4096 -f /etc/ssh/ssh_host_rsa_key -N "" -q
+- chmod 600 /etc/ssh/ssh_host_*_key
+- chmod 644 /etc/ssh/ssh_host_*_key.pub
 
 ca_certs:
 # CN=Shortrib Labs Root E1
@@ -210,20 +221,10 @@ runcmd:
       echo "[harden-ssh] Added $user to ssher group"
     fi
   done
-# SSH hardening script - regenerate host keys, harden moduli, validate config
+# SSH hardening script - harden moduli, validate config
 - |
   set -euo pipefail
   log() { echo "[harden-ssh] $*"; }
-
-  # Regenerate host keys - Ed25519 + RSA-4096 only
-  log "Regenerating host keys (Ed25519 + RSA-4096 only)..."
-  cd /etc/ssh
-  rm -f ssh_host_*key*
-  ssh-keygen -t ed25519 -f ssh_host_ed25519_key -N "" -q
-  ssh-keygen -t rsa -b 4096 -f ssh_host_rsa_key -N "" -q
-  chmod 600 ssh_host_*_key
-  chmod 644 ssh_host_*_key.pub
-  log "Host keys regenerated."
 
   # Harden moduli file - minimum 3072-bit DH groups
   if [[ -f /etc/ssh/moduli ]]; then
@@ -265,3 +266,12 @@ runcmd:
   fi
 
   log "SSH hardening complete."
+# Generate iSCSI initiator name for Nutanix CSI
+- |
+  if [ -f /etc/iscsi/initiatorname.iscsi ]; then
+    if grep -q "GenerateName=yes" /etc/iscsi/initiatorname.iscsi; then
+      echo "InitiatorName=$(iscsi-iname)" > /etc/iscsi/initiatorname.iscsi
+      systemctl restart iscsid || true
+      echo "[iscsi] Generated iSCSI initiator name"
+    fi
+  fi


### PR DESCRIPTION
TL;DR
-----

Adds remaining configuration for Nutanix Files storage class that was missed in #47 and #48.

Details
--------

**SOPS configuration** (`.sops.yaml`)
- Updates `encrypted_regex` to `.*password` pattern to encrypt `file_server_password`

**k0sctl template** (`k0sctl.tftpl`)
- Adds upload of `nutanix-files-storageclass.yaml` to manifests
- Changes Nutanix CSI Helm values to use managed secret (`createSecret: false`) instead of inline credentials

**Cloud-init** (`user-data.tftpl`)
- Adds `nfs-common` and `open-iscsi` packages required for NFS and iSCSI volumes
- Moves SSH host key regeneration to `bootcmd` for earlier execution
- Adds iSCSI initiator name generation for Nutanix CSI