### PR TITLE
Fixes ACME `ClusterIssuer` manifests

### DIFF
--- a/manifests/acme/00-shortrib-clusterissuer.yaml
+++ b/manifests/acme/00-shortrib-clusterissuer.yaml
@@ -12,4 +12,4 @@ spec:
     solvers:
     - http01:
         ingress:
-          ingressClassName: contour
+          ingressClassName: traefik

--- a/manifests/acme/01-letsencrypt-clusterissuer.yaml
+++ b/manifests/acme/01-letsencrypt-clusterissuer.yaml
@@ -13,5 +13,5 @@ spec:
         cloudflare:
           apiTokenSecretRef:
             name: cloudflare-api-token
-            key: api-token
+            key: api-key
 


### PR DESCRIPTION
TL;DR
-----

Corrects configuration errors in ACME `ClusterIssuer` manifests that prevent certificate issuance.

Details
-------

- **shortrib-clusterissuer**: Updates `ingressClassName` from `contour` to `traefik` to match the deployed ingress controller
- **letsencrypt-clusterissuer**: Corrects the Cloudflare `apiTokenSecretRef` key from `api-token` to `api-key` to match the actual secret key name

🤖 Generated with [Claude Code](https://claude.com/claude-code)